### PR TITLE
Shorter maximum fire search radius for idle trucks from 50 m to 40 m

### DIFF
--- a/SmarterFirefighters/FirefighterAI.cs
+++ b/SmarterFirefighters/FirefighterAI.cs
@@ -105,7 +105,7 @@ namespace SmarterFirefighters
         {
             if ((vehicleData.m_flags & (Vehicle.Flags.GoingBack | Vehicle.Flags.WaitingTarget)) != 0)
             {
-                ushort newTarget = NewFireAI.FindBurningBuilding(vehicleData.GetLastFramePosition(), 50f);
+                ushort newTarget = NewFireAI.FindBurningBuilding(vehicleData.GetLastFramePosition(), 40f);
                 if (newTarget != 0)
                 {
                     vehicleData.Info.m_vehicleAI.SetTarget(vehicleID, ref vehicleData, newTarget);


### PR DESCRIPTION
Shorter search radius prevents firefighter citizens from being too far from parent vehicle. If they are too far away, the hose trailing behind them can look odd.