### PR TITLE
Update Harmony and make compatible with More CitizenUnits mod

### DIFF
--- a/SmarterFirefighters/FirefighterAI.cs
+++ b/SmarterFirefighters/FirefighterAI.cs
@@ -62,6 +62,7 @@ namespace SmarterFirefighters
         public static void  TargetCimsParentVehicleTarget(ushort vehicleID, ref Vehicle vehicleData)
         {
             CitizenManager instance = Singleton<CitizenManager>.instance;
+            uint numCitizenUnits = instance.m_units.m_size;
             uint num = vehicleData.m_citizenUnits;
             int num2 = 0;
             while (num != 0)
@@ -86,7 +87,7 @@ namespace SmarterFirefighters
                     //UnityEngine.Debug.Log("Cim " + instance2 + " from Firetruck ID: " + vehicleID + " retargeted to " + vehicleData.m_targetBuilding);
                 }
                 num = nextUnit;
-                if (++num2 > 524288)
+                if (++num2 > numCitizenUnits)
                 {
                     CODebugBase<LogChannel>.Error(LogChannel.Core, "Invalid list detected!\n" + Environment.StackTrace);
                     break;

--- a/SmarterFirefighters/SmarterFirefighters.csproj
+++ b/SmarterFirefighters/SmarterFirefighters.csproj
@@ -31,20 +31,20 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.0.1.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Lib.Harmony.2.0.1\lib\net35\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.1.1.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Lib.Harmony.2.1.1\lib\net35\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\TEMP\ProjDLLs\Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\Assembly-CSharp.dll</HintPath>
     </Reference>
-    <Reference Include="CitiesHarmony.API, Version=1.0.5.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\CitiesHarmony.API.1.0.5\lib\net35\CitiesHarmony.API.dll</HintPath>
+    <Reference Include="CitiesHarmony.API, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\CitiesHarmony.API.2.0.0\lib\net35\CitiesHarmony.API.dll</HintPath>
     </Reference>
     <Reference Include="ColossalManaged">
-      <HintPath>..\..\..\..\..\..\TEMP\ProjDLLs\ColossalManaged.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ColossalManaged.dll</HintPath>
     </Reference>
     <Reference Include="ICities">
-      <HintPath>..\..\..\..\..\..\TEMP\ProjDLLs\ICities.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\ICities.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -53,7 +53,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\TEMP\ProjDLLs\UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Cities_Skylines\Cities_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/SmarterFirefighters/packages.config
+++ b/SmarterFirefighters/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CitiesHarmony.API" version="1.0.5" targetFramework="net35" />
-  <package id="Lib.Harmony" version="2.0.1" targetFramework="net35" />
+  <package id="CitiesHarmony.API" version="2.0.0" targetFramework="net35" />
+  <package id="CitiesHarmony.Harmony" version="2.0.4" targetFramework="net35" developmentDependency="true" />
+  <package id="Lib.Harmony" version="2.1.1" targetFramework="net35" />
 </packages>


### PR DESCRIPTION
Obsolete CitiesHarmony API bundled with the mod can cause issues; need to update to latest version.

Removed hardcoded CitizenUnit limit and replaced with dynamic check to ensure compatibility with mods that increase CitizenUnit limits.